### PR TITLE
Rename the two primary API methods

### DIFF
--- a/can-worker-observable.js
+++ b/can-worker-observable.js
@@ -62,7 +62,7 @@ function linkedProxy(worker, name) {
   return proxy;
 }
 
-function proxy(worker) {
+function connect(worker) {
   if(!worker[API]) {
     worker[API] = new Proxy({}, {
       get: function(target, key, receiver) {
@@ -75,7 +75,7 @@ function proxy(worker) {
   return worker[API];
 }
 
-function link(name, object) {
+function provide(name, object) {
   if(arguments.length === 1) {
     object = name;
     name = object.name;
@@ -127,8 +127,8 @@ function setupListener() {
 }
 
 var workerObservable = {
-  link: link,
-  proxy: proxy
+  provide: provide,
+  connect: connect
 };
 
 module.exports = workerObservable;

--- a/readme.md
+++ b/readme.md
@@ -7,16 +7,15 @@ __WIP__: This is only a proof of concept. Do not use.
 See the `test/tests/basics` folder for a full example. It looks like this:
 
 ```js
-var stache = require("can-stache");
-var workerObservable = require("can-worker-observable");
+const stache = require("can-stache");
+const { connect }  = require("can-worker-observable");
 
-var worker = new Worker("./path/to/worker.js");
+let worker = new Worker("./path/to/worker.js");
 
-var api = workerObservable.proxy(worker);
-var FooViewModel = api.FooViewModel;
+let { FooViewModel } = connect(worker);
 
-var vm = new FooViewModel();
+let vm = new FooViewModel();
 
-var view = stache("<span>Hello {{foo}}</span>");
+let view = stache("<span>Hello {{foo}}</span>");
 document.body.appendChild(view(vm));
 ```

--- a/test/tests/basics/worker.js
+++ b/test/tests/basics/worker.js
@@ -1,12 +1,10 @@
 var DefineMap = require("can-define/map/map");
-var workerObservable = require("can-worker-observable");
+var obs = require("can-worker-observable");
 
 var FooViewModel = DefineMap.extend("FooViewModel", {
-  seal: false
-}, {
   foo: {
-    value: "bar"
+    default: "bar"
   }
 });
 
-workerObservable.link(FooViewModel);
+obs.provide(FooViewModel);

--- a/test/worker_observable_test.js
+++ b/test/worker_observable_test.js
@@ -1,6 +1,7 @@
 var canReflect = require("can-reflect");
 var QUnit = require("steal-qunit");
 var workerObservable = require("../can-worker-observable");
+var connect = workerObservable.connect;
 
 function before(hooks, fn) {
 	if(fn.result) return fn.result;
@@ -23,7 +24,7 @@ QUnit.module("basics", function(hooks) {
 	before(hooks, function(assert) {
 		var pth = __dirname + "/../node_modules/steal/steal.js?config=package.json!npm&baseURL=/&main=test/tests/basics/worker";
 		var worker = new Worker(pth);
-		this.api = workerObservable.proxy(worker);
+		this.api = connect(worker);
 	});
 
 	QUnit.module("Constructors", function(){


### PR DESCRIPTION
This changes the names of a couple of things:

* proxy -> connect
* link -> provide